### PR TITLE
Fix invoice calculation route path

### DIFF
--- a/app/routers/invoices.py
+++ b/app/routers/invoices.py
@@ -496,14 +496,14 @@ def generate_invoice_calculation(
     return generator.generate_invoice(request)
 
 
-@router.post("/create-from-calculation", response_model=InvoiceSchema)
+@router.post("/create-from-calculation/{project_id}", response_model=InvoiceSchema)
 def create_invoice_from_calculation(
+    project_id: int,
     request_data: dict,
     session: Session = Depends(get_session),
     current_user=Depends(require_buchhalter_or_admin),
 ):
     """Rechnung basierend auf einer vorherigen Berechnung anlegen."""
-    project_id = request_data.get("project_id")
     calculation = request_data.get("calculation")
     invoice_number = request_data.get("invoice_number")
     client_name = request_data.get("client_name")
@@ -512,7 +512,6 @@ def create_invoice_from_calculation(
     missing = [
         field
         for field, value in {
-            "project_id": project_id,
             "calculation": calculation,
             "invoice_number": invoice_number,
             "client_name": client_name,

--- a/tests/unit/test_invoice_routes.py
+++ b/tests/unit/test_invoice_routes.py
@@ -1,0 +1,27 @@
+"""Tests für die Rechnungs-Router-Konfiguration."""
+
+import os
+import sys
+from pathlib import Path
+
+from fastapi.routing import APIRoute
+
+# Minimal erforderliche Settings setzen, damit der Auth-Stack geladen werden kann.
+os.environ.setdefault("SECRET_KEY", "test-secret-key")
+
+# Sicherstellen, dass das Projektverzeichnis im Python-Pfad liegt.
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from app.main import app  # noqa: E402  # Import nach Setzen der Umgebung
+
+
+def test_create_invoice_from_calculation_route_uses_project_path() -> None:
+    """Stellt sicher, dass der Endpunkt den erwarteten Pfad mit Projekt-ID nutzt."""
+    route_paths = {
+        route.path
+        for route in app.routes
+        if isinstance(route, APIRoute) and route.name == "create_invoice_from_calculation"
+    }
+    assert "/invoices/create-from-calculation/{project_id}" in route_paths


### PR DESCRIPTION
## Summary
- add a project_id path parameter to the invoice creation-from-calculation endpoint
- ensure project validation now uses the path parameter instead of expecting it in the payload
- add a regression test that checks the router exposes the corrected path

## Testing
- pytest tests/unit/test_invoice_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68df4a69c5ac83238409ed08ed9516d7